### PR TITLE
Fix Excel binding for workflow report exports

### DIFF
--- a/packages/behin-simple-workflow-report/src/SimpleWorkflowReportProvider.php
+++ b/packages/behin-simple-workflow-report/src/SimpleWorkflowReportProvider.php
@@ -13,7 +13,7 @@ class SimpleWorkflowReportProvider extends ServiceProvider
      */
     public function register()
     {
-        //
+        $this->app->register(\Maatwebsite\Excel\ExcelServiceProvider::class);
     }
 
     /**


### PR DESCRIPTION
## Summary
- register the Maatwebsite Excel service provider inside the SimpleWorkflow report package to ensure the facade binding is available during exports

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4d3b82f0c833284019afdcb770a38