### PR TITLE
Resolve city display in workflow all requests report

### DIFF
--- a/packages/behin-simple-workflow-report/src/Controllers/Core/AllRequestsReportController.php
+++ b/packages/behin-simple-workflow-report/src/Controllers/Core/AllRequestsReportController.php
@@ -4,16 +4,14 @@ namespace Behin\SimpleWorkflowReport\Controllers\Core;
 
 use App\Http\Controllers\Controller;
 use Behin\Ami\Services\CallHistoryService;
-use Behin\SimpleWorkflow\Models\Core\Cases;
 use Behin\SimpleWorkflow\Models\Core\Inbox;
 use Behin\SimpleWorkflowReport\Exports\AllRequestsReportExport;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Contracts\View\View;
+use Illuminate\Database\Query\Builder;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Schema;
 use Maatwebsite\Excel\Facades\Excel;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Behin\SimpleWorkflow\Models\Core\ViewModel;
@@ -35,6 +33,9 @@ class AllRequestsReportController extends Controller
             $row->last_status = Inbox::where('case_id', $row->id)
                 ->whereNotIn('status', ['done', 'doneByOther', 'canceled'])
                 ->get();
+            $row->city = collect([$row->province_name ?? null, $row->city_name ?? null])
+                ->filter()
+                ->implode(' - ') ?: null;
             return $row;
         });
 
@@ -46,9 +47,9 @@ class AllRequestsReportController extends Controller
         ]);
     }
 
-    protected function baseQuery()
+    protected function baseQuery(): Builder
     {
-        return DB::table('wf_cases as c')
+        $caseDataQuery = DB::table('wf_cases as c')
             ->leftJoin('wf_variables as v', 'c.id', '=', 'v.case_id')
             ->select(
                 'c.id',
@@ -60,10 +61,19 @@ class AllRequestsReportController extends Controller
                 DB::raw("MAX(CASE WHEN `key` IN ('guild_number') THEN value END) as guild_number"),
                 DB::raw("MAX(CASE WHEN `key` IN ('guild_name') THEN value END) as guild_name"),
                 DB::raw("MAX(CASE WHEN `key` = 'catagory' THEN value END) as catagory"),
-                DB::raw("MAX(CASE WHEN `key` IN ('city') THEN value END) as city"),
+                DB::raw("MAX(CASE WHEN `key` IN ('city') THEN value END) as city_id"),
                 DB::raw("MAX(CASE WHEN `key` IN ('customer_info_is_aproved') THEN value END) as customer_info_is_aproved"),
             )
             ->groupBy('c.id', 'c.number');
+
+        return DB::query()
+            ->fromSub($caseDataQuery, 'case_data')
+            ->leftJoin('cities as city_lookup', 'case_data.city_id', '=', 'city_lookup.id')
+            ->select(
+                'case_data.*',
+                DB::raw('city_lookup.city as city_name'),
+                DB::raw('city_lookup.province as province_name')
+            );
     }
 
     protected function applyFilters($query, array $filters)
@@ -75,39 +85,43 @@ class AllRequestsReportController extends Controller
         }
 
         if (!empty($filters['case_number'])) {
-            $query->having('number', 'like', '%' . $filters['case_number'] . '%');
+            $query->where('number', 'like', '%' . $filters['case_number'] . '%');
         }
 
         if (!empty($filters['fullname'])) {
-            $query->having('fullname', 'like', '%' . $filters['fullname'] . '%');
+            $query->where('fullname', 'like', '%' . $filters['fullname'] . '%');
         }
 
         if (!empty($filters['mobile'])) {
-            $query->having('mobile', 'like', '%' . $filters['mobile'] . '%');
+            $query->where('mobile', 'like', '%' . $filters['mobile'] . '%');
         }
 
         if (!empty($filters['tel'])) {
-            $query->having('tel', 'like', '%' . $filters['tel'] . '%');
+            $query->where('tel', 'like', '%' . $filters['tel'] . '%');
         }
 
         if (!empty($filters['guild_number'])) {
-            $query->having('guild_number', 'like', '%' . $filters['guild_number'] . '%');
+            $query->where('guild_number', 'like', '%' . $filters['guild_number'] . '%');
         }
 
         if (!empty($filters['guild_name'])) {
-            $query->having('guild_name', 'like', '%' . $filters['guild_name'] . '%');
+            $query->where('guild_name', 'like', '%' . $filters['guild_name'] . '%');
         }
 
         if (!empty($filters['catagory'])) {
-            $query->having('catagory', 'like', '%' . $filters['catagory'] . '%');
+            $query->where('catagory', 'like', '%' . $filters['catagory'] . '%');
         }
 
         if (!empty($filters['city'])) {
-            $query->having('city', 'like', '%' . $filters['city'] . '%');
+            $query->where(function ($cityQuery) use ($filters) {
+                $cityQuery->where('city_name', 'like', '%' . $filters['city'] . '%')
+                    ->orWhere('province_name', 'like', '%' . $filters['city'] . '%')
+                    ->orWhere('city_id', 'like', '%' . $filters['city'] . '%');
+            });
         }
 
-        if (!empty($filters['customer_info_is_aaproved'])) {
-            $query->having('customer_info_is_aaproved', 'like', '%' . $filters['customer_info_is_aaproved'] . '%');
+        if (!empty($filters['customer_info_is_aproved'])) {
+            $query->where('customer_info_is_aproved', 'like', '%' . $filters['customer_info_is_aproved'] . '%');
         }
 
         if (!empty($filters['last_status'])) {
@@ -115,7 +129,7 @@ class AllRequestsReportController extends Controller
                 $subQuery->select(DB::raw(1))
                     ->from('wf_inbox as wi')
                     ->join('wf_task as wt', 'wt.id', '=', 'wi.task_id')
-                    ->whereColumn('wi.case_id', 'c.id')
+                    ->whereColumn('wi.case_id', 'case_data.id')
                     ->whereNotIn('wi.status', ['done', 'doneByOther', 'canceled'])
                     ->where('wt.name', 'like', '%' . $filters['last_status'] . '%');
             });
@@ -144,6 +158,9 @@ class AllRequestsReportController extends Controller
                 ->toArray();
 
             $row->last_status = implode(', ', $statuses);
+            $row->city = collect([$row->province_name ?? null, $row->city_name ?? null])
+                ->filter()
+                ->implode(' - ') ?: null;
             return $row;
         });
         // حالا خروجی اکسل ساده
@@ -154,12 +171,16 @@ class AllRequestsReportController extends Controller
     public function show(string $caseNumber): View
     {
         $row = $this->baseQuery()
-            ->where('c.number', $caseNumber)
+            ->where('number', $caseNumber)
             ->first();
 
         if (!$row) {
             abort(404);
         }
+
+        $row->city = collect([$row->province_name ?? null, $row->city_name ?? null])
+            ->filter()
+            ->implode(' - ') ?: null;
 
         // $row = $this->prepareRows(collect([$row]))->first();
 

--- a/packages/behin-simple-workflow-report/src/Exports/AllRequestsReportExport.php
+++ b/packages/behin-simple-workflow-report/src/Exports/AllRequestsReportExport.php
@@ -50,7 +50,10 @@ class AllRequestsReportExport implements FromCollection, WithHeadings, WithMappi
             $row['tel'] ?? null,
             $row['guild_number'] ?? null,
             $row['guild_name'] ?? null,
-            $row['city'] ?? null,
+            $row['city'] ?? collect([
+                $row['province_name'] ?? null,
+                $row['city_name'] ?? null,
+            ])->filter()->implode(' - '),
             $row['customer_info_is_aproved'] ?? null,
             $row['last_status'] ?? null,
         ];


### PR DESCRIPTION
## Summary
- join the cities table in the all requests report query so that province and city names are available instead of raw IDs
- update filtering and result preparation to expose a human readable "province - city" value in both the list and detail views
- adjust the export mapping to fall back to the resolved province and city names when building the spreadsheet output

## Testing
- php -l packages/behin-simple-workflow-report/src/Controllers/Core/AllRequestsReportController.php
- php -l packages/behin-simple-workflow-report/src/Exports/AllRequestsReportExport.php

------
https://chatgpt.com/codex/tasks/task_e_68e4dc34d0f483328a9eaf4f3820fecb